### PR TITLE
Automatically accept line if the line was empty, and AUTO_CD is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ shown in `fzf`, first to last):
 
    `export FZFZ_EXTRA_DIRS="~/MyDocuments '~/Desktop/Some Other Stuff'"`
 
-To use the plugin, simply hit `<CTRL-g>` anywhere on an empty zsh
-command-line, and it will bring up a list of directories according to the
-three categories above (mixed together).  Select one, perhaps typing to filter
-the list, and hit Enter - you'll change to that directory (assuming you have
-the `AUTO_CD` zsh option turned on, which is recommended). This is similar to
-the default **Ctrl-T** binding already provided by the [fzf zsh key-bindings
+To use the plugin, simply hit `<CTRL-g>` on the zsh command-line, and it will
+bring up a list of directories according to the three categories above (mixed
+together).  Select one, perhaps typing to filter the list, and hit Enter - the
+path to the selected directory will be inserted into the command line.  If you
+started with an empty command line, and you have the `AUTO_CD` zsh option
+turned on you'll change to that directory instantly.
+
+This is similar to the default **Ctrl-T** binding already provided by the
+[fzf zsh key-bindings
 file](https://github.com/junegunn/fzf/blob/master/shell/key-bindings.zsh). At
 the moment, this plugin doesn't allow the **Ctrl-G** keybinding to be
 customized, but you can change by simply forking the plugin and editing the

--- a/fzf-z.plugin.zsh
+++ b/fzf-z.plugin.zsh
@@ -64,11 +64,23 @@ __fzfz() {
 }
 
 fzfz-file-widget() {
+    local shouldAccept=$(should-accept-line)
     LBUFFER="${LBUFFER}$(__fzfz)"
     local ret=$?
     zle redisplay
     typeset -f zle-line-init >/dev/null && zle zle-line-init
+    if [[ $ret -eq 0 && -n "$BUFFER" && -n "$shouldAccept" ]]; then
+        zle .accept-line
+    fi
     return $ret
+}
+
+# Accept the line if the buffer was empty before invoking the file widget, and
+# the `auto_cd` option is set.
+should-accept-line() {
+    if [[ ${#${(z)BUFFER}} -eq 0 && -o auto_cd ]]; then
+        echo "true";
+    fi
 }
 
 zle -N fzfz-file-widget


### PR DESCRIPTION
Call `zle .accept-line` to run change to the selected directory immediately if all of these conditions are met:

- the command line was empty before pressing the activation hotkey
- the `AUTO_CD` option is set
- the user selected a directory (as opposed to pressing escape, or pressing empty with an empty completion list)
- the exit status of `__fzfz` was zero

This change also updates the readme to explain the new behavior, and to clarify what happens when activating fzf-z on a non-empty command line.

This change addresses issue #11.