### PR TITLE
Use /usr/bin/env bash  instead of /bin/bash

### DIFF
--- a/recentdirs.sh
+++ b/recentdirs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
bash isn't at /bin/bash on nixos nor some other platform iirc. This way we let PATH tell us where to get it from.