### PR TITLE
Detect if tac is in PATH even when in macOS

### DIFF
--- a/fzfz
+++ b/fzfz
@@ -27,7 +27,7 @@ fi
 
 SCRIPT_PATH="${0:A:h}"
 
-if [[ $OSTYPE == darwin* ]]; then
+if [[ $OSTYPE == darwin* && -z $(whence tac) ]]; then
     REVERSER='tail -r'
 else
     REVERSER='tac'


### PR DESCRIPTION
This is needed for example when using Nix which will add tac and GNU coreutils to the PATH.