### PR TITLE
Added `$FZF_BIN_PATH` for customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You must also have [fzf](https://github.com/junegunn/fzf) installed.
 These tools must be in your `$PATH`. These have to be installed irrespective
 of how you use `fzf-z`.
 
+You can set the full path to `fzf` binary with environment variable
+`FZF_BIN_PATH`, or it uses the one found in your `$PATH`.
+
 *Note*: When you first use `fzf-z`, if you have configured
 `FZFZ_RECENT_DIRS_TOOL` to use `z` (which is the default), it will dynamically
 download `z.sh` for its own internal use. You still need to have the [z

--- a/fzfz
+++ b/fzfz
@@ -4,6 +4,7 @@
 # override them by exporting them from your ~/.zshrc. See README for more
 # details.
 
+FZF_BIN_PATH=${FZF_BIN_PATH:="fzf"}
 FZFZ_EXCLUDE_PATTERN=${FZFZ_EXCLUDE_PATTERN:="\/.git"}
 FZFZ_EXTRA_OPTS=${FZFZ_EXTRA_OPTS:=""}
 FZFZ_UNIQUIFIER=${FZFZ_UNIQUIFIER:="awk '!seen[\$0]++' 2>&1"}
@@ -74,7 +75,7 @@ fi
 RECENT_DIRS="{ $SCRIPT_PATH/recentdirs.sh }"
 RECENTLY_USED_DIRS="{ $RECENT_DIRS | $REVERSER | sed 's/^[[:digit:].]*[[:space:]]*//' }"
 
-FZF_COMMAND="fzf --height ${FZF_TMUX_HEIGHT:-40%} ${FZFZ_EXTRA_OPTS} --no-sort --tiebreak=end,index -m --preview='$FZFZ_PREVIEW_COMMAND | head -\$LINES'"
+FZF_COMMAND="${FZF_BIN_PATH} --height ${FZF_TMUX_HEIGHT:-40%} ${FZFZ_EXTRA_OPTS} --no-sort --tiebreak=end,index -m --preview='$FZFZ_PREVIEW_COMMAND | head -\$LINES'"
 
 COMMAND="{ $SUBDIRS ; $RECENTLY_USED_DIRS ; $EXTRA_DIRS; } | $FZFZ_UNIQUIFIER | $FZF_COMMAND"
 eval $COMMAND


### PR DESCRIPTION
It's convenient to allow users to customise which `fzf` they want to
use. This commit add a new environment variable, `FZF_BIN_PATH`, via
which users can configure the full path to the `fzf` binary that they
want `fzf-z` to use.