### PR TITLE
Make autojump work on macOS

### DIFF
--- a/recentdirs.sh
+++ b/recentdirs.sh
@@ -16,7 +16,12 @@ if [[ $FZFZ_RECENT_DIRS_TOOL == "z" ]]; then
     source "$SCRIPT_PATH/z.sh"
     _z -l 2>&1 && exit 0 || exit 0
 elif [[ $FZFZ_RECENT_DIRS_TOOL == "autojump" ]]; then
-    autojump -s | tac | tail +8 | tac | awk '{print $2}'
+    if [[ $OSTYPE == darwin* && -z $(whence tac) ]]; then
+        REVERSER='tail -r'
+    else
+        REVERSER='tac'
+    fi
+    autojump -s | $REVERSER | tail +8 | $REVERSER | awk '{print $2}'
 elif [[ $FZFZ_RECENT_DIRS_TOOL == "fasd" ]]; then
     fasd -dl 2>&1 && exit 0 || exit 0
 else


### PR DESCRIPTION
macOS doesn't come with tac, and the snippet is copied from [`fzfz`](https://github.com/andrewferrier/fzf-z/blob/master/fzfz#L31), so should be safe to merge.
https://github.com/andrewferrier/fzf-z/blob/4395e87dd43c4404699bb655a0e331abd3403b13/fzfz#L31-L35

https://github.com/andrewferrier/fzf-z/blob/4395e87dd43c4404699bb655a0e331abd3403b13/fzfz#L76